### PR TITLE
Fixed the labelling when printing the symmetry information 

### DIFF
--- a/easyunfold/cli.py
+++ b/easyunfold/cli.py
@@ -444,13 +444,13 @@ def print_symmetry_data(kset):
 
     # Print space group information
     sc_spg = kset.metadata['symmetry_dataset_sc']
-    click.echo('Primitive cell information:')
+    click.echo('Supercell cell information:')
     click.echo(' ' * 8 + f'Space group number: {sc_spg["number"]}')
     click.echo(' ' * 8 + f'Internation symbol: {sc_spg["international"]}')
     click.echo(' ' * 8 + f'Point group: {sc_spg["pointgroup"]}')
 
     pc_spg = kset.metadata['symmetry_dataset_pc']
-    click.echo('\nSupercell cell information:')
+    click.echo('\nPrimitive cell information:')
     click.echo(' ' * 8 + f'Space group number: {pc_spg["number"]}')
     click.echo(' ' * 8 + f'Internation symbol: {pc_spg["international"]}')
     click.echo(' ' * 8 + f'Point group: {pc_spg["pointgroup"]}')


### PR DESCRIPTION
Just a super simple fix. Originally, when you run `easyunfold generate` it prints the primitive cell information under the heading supercell cell information and vice versa.

<img width="695" alt="unfold_orig" src="https://user-images.githubusercontent.com/56972784/194023961-d94b1b00-80cf-44d1-b460-283325691c50.png">

Now with the fix:

<img width="694" alt="unfold_fix" src="https://user-images.githubusercontent.com/56972784/194023996-7011807e-4fe2-4081-b564-9c380509b6e3.png">
