### PR TITLE
Allow customized terminal color for projected spectral function 

### DIFF
--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -2,11 +2,23 @@
 Plotting utilities
 """
 import matplotlib.pyplot as plt
+
 import numpy as np
-from .unfold import UnfoldKSet, clean_latex_string
+from colormath.color_conversions import convert_color
+from colormath.color_objects import (
+    HSVColor,
+    LabColor,
+    LCHabColor,
+    LCHuvColor,
+    XYZColor,
+    sRGBColor,
+)
+from matplotlib.colors import to_rgb
+
+from .unfold import UnfoldKSet, clean_latex_string, parse_atoms_idx
 from .effective_mass import EffectiveMass
 
-# pylint: disable=too-many-locals
+# pylint: disable=too-many-locals, too-many-arguments
 
 
 class UnfoldPlotter:
@@ -112,7 +124,89 @@ class UnfoldPlotter:
             fig.show()
         return fig
 
-    def _add_kpoint_labels(self, ax):
+    def plot_spectral_function_rgba(
+            self,
+            engs,
+            sf,
+            eref=None,
+            figsize=(4, 3),
+            ylim=(-3, 3),
+            dpi=150,
+            intensity=1.0,
+            save=False,
+            ax=None,
+            show=False,
+            title=None,
+            vmin=None,
+            vmax=None,
+    ):
+        """
+        Plot spectral function.
+
+        Args:
+            engs (numpy.ndarray): The energies of the spectral functions.
+            sf (np.ndarray): An array of the spectral function.
+            eref (float): Reference energy to be used - this energy will be set as zero.
+            figsize: Size of the figure.
+            ylim: Plotting limit for the y-axis, with respect to `eref`.
+            dpi: DPI of the generated graph.
+            vscale: A scaling factor for the colour map.
+            contour_plot (bool): Whether to use contour plot instead of normal meshed color map.
+            alpha (float): Alpha for the color map.
+            save (str): Name of the file where the generated figure is saved.
+            ax: An existing plotting axis to be be used.
+            vmin (float): Minimum value for the color map.
+            vmax (float): Maximum value for the color map.
+            cmap (str): Name of the color map to be used.
+
+        Returns:
+            The figure generated containing the spectral function.
+        """
+        unfold = self.unfold
+        nspin = sf.shape[0]
+
+        if eref is None:
+            eref = unfold.calculated_quantities.get('vbm', 0.0)
+
+        if ax is None:
+            if nspin == 1:
+                fig, ax = plt.subplots(1, 1, figsize=figsize, dpi=dpi)
+                axes = [ax]
+            else:
+                fig, axes = plt.subplots(1, 2, figsize=figsize, dpi=dpi)
+        else:
+            if not isinstance(ax, list):
+                axes = [ax]
+            else:
+                axes = ax
+            fig = axes[0].figure
+
+        mask = (engs < (ylim[1] + eref)) & (engs > (ylim[0] + eref))
+        vmin = sf[:, mask, :, 3].min() if vmin is None else vmin
+
+        if vmax is None:
+            vmax = sf[:, mask, :, 3].max()
+
+        # Clip the alpha range
+        alpha = sf[:, :, :, 3]
+        alpha = (alpha - vmin) * (vmax - vmin) * intensity
+        alpha = np.clip(alpha, 0, 1)
+        sf[:, :, :, 3] = alpha
+
+        for ispin, ax_ in zip(range(nspin), axes):
+            ax_.imshow(sf[ispin], extent=[0, sf.shape[2], max(engs) - eref, min(engs) - eref], aspect='auto')
+            ax_.set_ylim(ylim)
+            ax_.set_title(title)
+            self._add_kpoint_labels(ax_, x_is_kidx=True)
+
+        fig.tight_layout(pad=0.2)
+        if save:
+            fig.savefig(save, dpi=300)
+        if show:
+            fig.show()
+        return fig
+
+    def _add_kpoint_labels(self, ax, x_is_kidx=False):
         """Add labels to the kpoints"""
         # Label the kpoints
         labels = self.unfold.kpoint_labels
@@ -122,7 +216,10 @@ class UnfoldPlotter:
         tick_locs = []
         tick_labels = []
         for index, label in labels:
-            xloc = kdist[index]
+            if x_is_kidx:
+                xloc = index
+            else:
+                xloc = kdist[index]
             ax.axvline(x=xloc, lw=0.5, color='k', ls=':', alpha=0.8)
             tick_locs.append(xloc)
             tick_labels.append(clean_latex_string(label))
@@ -289,3 +386,212 @@ class UnfoldPlotter:
         if show:
             fig.show()
         return fig
+
+    def plot_projected(
+        self,
+        procar,
+        eref=None,
+        gamma=False,
+        npoints=2000,
+        sigma=0.2,
+        ncl=False,
+        symm_average=True,
+        figsize=(4, 3),
+        ylim=(-3, 3),
+        dpi=150,
+        vscale=1.0,
+        contour_plot=False,
+        alpha=1.0,
+        save=False,
+        ax=None,
+        vmin=None,
+        vmax=None,
+        cmap='PuRd',
+        show=False,
+        title=None,
+        atoms_idx=None,
+        orbitals=None,
+        intensity=1.0,
+        use_subplot=False,
+        colors=None,
+        colorspace='lab',
+    ):
+        """
+        Plot projected sepctral function onto multiple subplots or a single plot with colormapping.
+
+        This simply computes the spectral function at each orbital/atoms sites and plot them onto
+        multiple subplots. The columns are for each orbital and the rows are for each spin channel.
+        """
+
+        unfoldset = self.unfold
+        unfoldset.load_procar(procar)
+        nspins = unfoldset.calculated_quantities['spectral_weights_per_set'][0].shape[0]
+
+        atoms_idx_subplots = atoms_idx.split('|')
+        if orbitals is not None:
+            orbitals_subsplots = atoms_idx.split('|')
+
+            # Special case: if only one set is passed, apply it to all atomic specifications
+            if len(orbitals_subsplots) == 1:
+                orbitals_subsplots = orbitals_subsplots * len(atoms_idx_subplots)
+
+            if len(orbitals_subsplots) != len(atoms_idx_subplots):
+                raise ValueError('The number of elected orbitals and atoms indices are not matched.')
+        # If not set, use all for all subsets
+        else:
+            orbitals_subsplots = ['all'] * len(atoms_idx_subplots)
+
+        # Load the data
+
+        nsub = len(atoms_idx_subplots)
+
+        all_sf = []
+        vmaxs = []
+
+        if eref is None:
+            eref = unfoldset.calculated_quantities.get('vbm', 0.0)
+
+        # Collect spectral functions and scale
+        for this_idx, this_orbitals in zip(atoms_idx_subplots, orbitals_subsplots):
+            # Setup the atoms_idx and orbitals
+            this_idx, this_orbitals = process_projection_options(this_idx, this_orbitals)
+            eng, spectral_function = unfoldset.get_spectral_function(gamma=gamma,
+                                                                     npoints=npoints,
+                                                                     sigma=sigma,
+                                                                     ncl=ncl,
+                                                                     atoms_idx=this_idx,
+                                                                     orbitals=this_orbitals,
+                                                                     symm_average=symm_average)
+            all_sf.append(spectral_function)
+
+            emin, emax = ylim
+            # Clip the effective range
+            mask = (eng < (emax + eref)) & (eng > (emin + eref))
+            vmin = spectral_function[:, mask, :].min()
+            vmax = spectral_function[:, mask, :].max()
+            vmax = (vmax - vmin) * vscale + vmin
+            vmaxs.append(vmax)
+
+        # Workout the vmax and vmin
+        vmax = max(vmaxs)
+        vmin = 0.
+
+        if use_subplot:
+            fig, axs = plt.subplots(nspins, len(atoms_idx_subplots), sharex=True, sharey=True, squeeze=False, figsize=(3.0 * nsub, 4.0))
+            # Plot the spectral function with constant colour scales
+            for spectral_function, i in zip(all_sf, range(len(atoms_idx_subplots))):
+                plotter = UnfoldPlotter(unfoldset)
+                plotter.plot_spectral_function(
+                    eng,
+                    spectral_function,
+                    eref=eref,
+                    save=save,
+                    vscale=vscale,
+                    vmax=vmax,
+                    vmin=vmin,
+                    cmap=cmap,
+                    title=title,
+                    ax=axs[:, i].tolist(),
+                    figsize=figsize,
+                    show=show,
+                    contour_plot=contour_plot,
+                    alpha=alpha,
+                    dpi=dpi,
+                    ylim=ylim,
+                )
+        else:
+            # Make a combined plot
+            sf_size = all_sf[0].shape
+            stacked_sf = np.stack(all_sf, axis=-1).reshape(np.prod(sf_size), len(all_sf))
+
+            # Construct the color basis
+            if colors is None:
+                default_colors = ['b', 'r', 'g', 'brown']
+                colors = default_colors[0:len(all_sf)]
+            # Compute spectral weight data with RGB reshape it back into the shape (nengs, nk, 3)
+            sf_rgb = interpolate_colors(colors, stacked_sf, colorspace, normalize=True).reshape(sf_size + (3,))
+            sf_sum = np.sum(all_sf, axis=0)[:, :, :, None]
+            sf_rgba = np.concatenate([sf_rgb, sf_sum], axis=-1)
+
+            if ax is None:
+                fig, axs = plt.subplots(1, nspins, figsize=figsize, squeeze=True)
+
+            self.plot_spectral_function_rgba(
+                eng,
+                sf_rgba,
+                eref=eref,
+                save=save,
+                title=title,
+                intensity=intensity,
+                ax=axs,
+                figsize=figsize,
+                show=show,
+                dpi=dpi,
+                ylim=ylim,
+            )
+
+        return fig
+
+
+def interpolate_colors(colors, weights, colorspace='lab', normalize=True):
+    """
+    Interpolate colors at a number of points within a colorspace.
+
+    Args:
+        colors(str): A list of colors specified in any way supported by matplotlib.
+        weights (list): A list of weights with the shape (n, N). Where the N values of
+            the last axis give the amount of N colors supplied in `colors`.
+        colorspace (str): The colorspace in which to perform the interpolation. The
+            allowed values are rgb, hsv, lab, luvlc, lablch, and xyz.
+    Returns:
+        A list of colors, specified in the rgb format as a (n, 3) array.
+    """
+
+    # Set up and check the color spaces
+    colorspace_mapping = {
+        'rgb': sRGBColor,
+        'hsv': HSVColor,
+        'lab': LabColor,
+        'luvlch': LCHuvColor,
+        'lablch': LCHabColor,
+        'xyz': XYZColor,
+    }
+
+    if colorspace not in list(colorspace_mapping.keys()):
+        raise ValueError(f'colorspace must be one of {colorspace_mapping.keys()}')
+
+    colorspace = colorspace_mapping[colorspace]
+
+    # Convert matplotlib color specification to colormath sRGB
+    colors_srgb = [sRGBColor(*to_rgb(c)) for c in colors]
+
+    colors_basis = [np.array(convert_color(srgb, colorspace, target_illuminant='d50').get_value_tuple()) for srgb in colors_srgb]
+
+    # ensure weights is a numpy array
+    weights = np.asarray(weights)
+
+    # Normalise the weights if needed
+    if normalize:
+        weights = weights / np.linalg.norm(weights, axis=1)[:, None]
+    weights = 3 / weights.shape[1] * weights
+
+    # perform the interpolation in the colorspace basis
+    interpolated_colors = colors_basis[0] * weights[:, 0][:, None]
+    for i in range(1, len(colors_basis)):
+        interpolated_colors += colors_basis[i] * weights[:, i][:, None]
+
+    # convert the interpolated colors back to RGB
+    rgb_colors = [convert_color(colorspace(*c), sRGBColor).get_value_tuple() for c in interpolated_colors]
+
+    # ensure all rgb values are less than 1 (sometimes issues in interpolation gives
+    return np.minimum(rgb_colors, 1)
+
+
+def process_projection_options(atoms_idx, orbitals):
+    """Process commandline type specifications"""
+    indices = parse_atoms_idx(atoms_idx)
+    if orbitals and orbitals != 'all':
+        orbitals = [token.strip() for token in orbitals.split(',')]
+    else:
+        orbitals = 'all'
+    return indices, orbitals

--- a/easyunfold/plotting.py
+++ b/easyunfold/plotting.py
@@ -189,7 +189,7 @@ class UnfoldPlotter:
 
         # Clip the alpha range
         alpha = sf[:, :, :, 3]
-        alpha = (alpha - vmin) * (vmax - vmin) * intensity
+        alpha = (alpha - vmin) / (vmax - vmin) * intensity
         alpha = np.clip(alpha, 0, 1)
         sf[:, :, :, 3] = alpha
 
@@ -506,7 +506,7 @@ class UnfoldPlotter:
 
             # Construct the color basis
             if colors is None:
-                default_colors = ['b', 'r', 'g', 'brown']
+                default_colors = ['r', 'g', 'b', 'purple']
                 colors = default_colors[0:len(all_sf)]
             # Compute spectral weight data with RGB reshape it back into the shape (nengs, nk, 3)
             sf_rgb = interpolate_colors(colors, stacked_sf, colorspace, normalize=True).reshape(sf_size + (3,))
@@ -573,7 +573,6 @@ def interpolate_colors(colors, weights, colorspace='lab', normalize=True):
     # Normalise the weights if needed
     if normalize:
         weights = weights / np.linalg.norm(weights, axis=1)[:, None]
-    weights = 3 / weights.shape[1] * weights
 
     # perform the interpolation in the colorspace basis
     interpolated_colors = colors_basis[0] * weights[:, 0][:, None]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 dynamic = ["version", "description"]
 requires-python = ">=3.7"
 
-dependencies = ["scipy", "numpy", "matplotlib", "ase", "spglib", "click", "monty", "tqdm", "tabulate"]
+dependencies = ["scipy", "numpy", "matplotlib", "ase", "spglib", "click", "monty", "tqdm", "tabulate", "colormath"]
 
 [project.urls]
 "Homepage" = "https://github.com/SMTG-UCL/easyunfold"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,10 +2,8 @@
 Tests for the CLI system
 """
 import os
-import urllib
 import pytest
 from pathlib import Path
-import shutil
 
 from monty.serialization import loadfn
 from click.testing import CliRunner

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,7 +72,7 @@ def test_unfold(si_project_dir, tag):
     if tag == '':
         output = runner.invoke(easyunfold, ['unfold', '--data-file', 'test.json', 'effective-mass'])
         assert 'Hole effective masses' in output.stdout
-        assert 'm_e             -1.38922            32  [0.0, 0.0, 0.0] (\Gamma)  [0.5, 0.5, 0.5] (L)' in output.stdout
+        assert r'm_e             -1.38922            32  [0.0, 0.0, 0.0] (\Gamma)  [0.5, 0.5, 0.5] (L)' in output.stdout
 
     # Do the plotting
     output = runner.invoke(easyunfold, ['unfold', '--data-file', 'test.json', 'plot'])


### PR DESCRIPTION
This is the final bits of code needed to allow custom colours to be used when generating projected plots. 

Supersedes #4 

Allow any terminal colours to used via interpolation in a specific colour space (default to RGB).   

Example output (MgO supercell example with projection):

```
easyunfold unfold  plot-projections --atoms-idx="1,2,3,4|5,6,7,8" --procar MgO_super/PROCAR  --emin="-5" --emax=15 --intensity=2  --combined --colors="r,b" --out-file unfold-proj.png
```

![image](https://user-images.githubusercontent.com/33688599/218322114-fb472cdd-5559-446a-9fa0-156e5bbdbbea.png)

```
easyunfold unfold  plot-projections --atoms-idx="1,2,3,4|5,6,7,8" --procar MgO_super/PROCAR  --emin="-5" --emax=15 --intensity=2  --combined --colors="xkcd:baby poop,xkcd:berry" --out-file unfold-proj.png
```

![image](https://user-images.githubusercontent.com/33688599/218322232-f0397ff9-f900-493b-823f-d5e617c83265.png)


A potential pitfall is that when there are multiple species, the colours may mix and become white. However, as long as the projections are well separated along the energy/kdistance axis. This should not be a problem.

The other issue is that the use of `imshow` means that it is not possible to have the xaxis in the scale consistent with the actual kpoint distance. This is because the sampled kpoints along the path may not take equal distances in each segment. 
The `pyplot.pcolormesh` solves this (as in the standard spectral function plot), but getting it to display colors from RGB(A) arrays requires calling directly the `matplotlib.collections.QuadMesh` constructor and supply colours, but it is difficult to have the colors in the right order it seems. 
