### PR TITLE
Update CI Docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        # Deply the documentation built only on the push even
+        if: ${{ (github.event_name != 'pull_request') && (github.repository == 'SMTG-UCL/easyunfold') }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs_build


### PR DESCRIPTION
Only deploy the documentation on push event of the `dev` and `master` branch